### PR TITLE
fixed router error

### DIFF
--- a/cdk.context.json
+++ b/cdk.context.json
@@ -9,5 +9,13 @@
   ],
   "acknowledged-issue-numbers": [
     34892
+  ],
+  "availability-zones:account=273578090199:region=us-east-1": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
   ]
 }

--- a/internal/stack/Frontend.go
+++ b/internal/stack/Frontend.go
@@ -60,6 +60,20 @@ func NewFrontendStack(scope constructs.Construct, id string, props *FrontendStac
 	frontendMain = awscloudfront.NewDistribution(stack, jsii.String("FrontendMain"), &awscloudfront.DistributionProps{
 		DefaultRootObject: jsii.String("index.html"),
 		DefaultBehavior:   cloudfrontMainBehavior,
+		ErrorResponses: &[]*awscloudfront.ErrorResponse{
+			{
+				HttpStatus:         jsii.Number(404),
+				ResponseHttpStatus: jsii.Number(200),
+				ResponsePagePath:   jsii.String("/index.html"),
+				Ttl:                awscdk.Duration_Seconds(jsii.Number(0)),
+			},
+			{
+				HttpStatus:         jsii.Number(403),
+				ResponseHttpStatus: jsii.Number(200),
+				ResponsePagePath:   jsii.String("/index.html"),
+				Ttl:                awscdk.Duration_Seconds(jsii.Number(0)),
+			},
+		},
 	})
 
 	awscdk.NewCfnOutput(stack, jsii.String("CloudFront_Main_Info"), &awscdk.CfnOutputProps{
@@ -85,6 +99,20 @@ func NewFrontendStack(scope constructs.Construct, id string, props *FrontendStac
 	frontendProduction = awscloudfront.NewDistribution(stack, jsii.String("FrontendProduction"), &awscloudfront.DistributionProps{
 		DefaultRootObject: jsii.String("index.html"),
 		DefaultBehavior:   cloudfrontProductionBehavior,
+		ErrorResponses: &[]*awscloudfront.ErrorResponse{
+			{
+				HttpStatus:         jsii.Number(404),
+				ResponseHttpStatus: jsii.Number(200),
+				ResponsePagePath:   jsii.String("/index.html"),
+				Ttl:                awscdk.Duration_Seconds(jsii.Number(0)),
+			},
+			{
+				HttpStatus:         jsii.Number(403),
+				ResponseHttpStatus: jsii.Number(200),
+				ResponsePagePath:   jsii.String("/index.html"),
+				Ttl:                awscdk.Duration_Seconds(jsii.Number(0)),
+			},
+		},
 	})
 
 	awscdk.NewCfnOutput(stack, jsii.String("CloudFront_Production_Info"), &awscdk.CfnOutputProps{


### PR DESCRIPTION
using /<router> in url returned an error, now it goes to right page just made sure that all errors returned /index.html

tiny pr but this is what the current production code is running on and is important for react router to work

later we will need to work with this stack again to update to auto create iam roles as well as move from oai to oac