### PR TITLE
feat: add POST /clubs endpoint + atomic insert query method

### DIFF
--- a/gateway/routes/club_routes.go
+++ b/gateway/routes/club_routes.go
@@ -58,4 +58,13 @@ func ClubRoutes(
 		Authorizer:  authorizer,
 	})
 
+	// POST /clubs
+	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
+		Path: jsii.String("/clubs"),
+		Methods: &[]awsapigatewayv2.HttpMethod{
+			awsapigatewayv2.HttpMethod_POST,
+		},
+		Integration: integrations.PostNewClub(stack, vpc, dbParams),
+		Authorizer:  authorizer,
+	})
 }

--- a/lambda/api/clubs/post/post.go
+++ b/lambda/api/clubs/post/post.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"cdk-infrastructure/database/models"
+	gateway_helpers "cdk-infrastructure/gateway/helpers"
+	authentication_utils "cdk-infrastructure/utils/auth"
+	validation_error "cdk-infrastructure/utils/errors"
+	"cdk-infrastructure/utils/query_client"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/go-playground/validator/v10"
+)
+
+var (
+	qc       *query_client.QueryClient
+	validate *validator.Validate
+)
+
+func init() {
+	validate = validator.New()
+
+	dbName := os.Getenv("DB_NAME")
+	arn := os.Getenv("DB_SECRET_ARN")
+	host := os.Getenv("DB_HOST")
+
+	client, err := query_client.NewClientFromHost(context.Background(), arn, dbName, host)
+
+	if err != nil {
+		log.Printf("Error creating query client: %v", err)
+
+		panic(err)
+	}
+
+	qc = client
+}
+
+type RequestBodySchema struct {
+	models.ClubDetailed `json:"club" validate:"required"`
+}
+
+func handler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	sub, email, err := authentication_utils.ExtractSubFromRequest(request.RequestContext)
+
+	if err != nil {
+		log.Printf("Error extracting sub from request: %v", err)
+
+		return gateway_helpers.NewClientErrorGatewayResponse(fmt.Sprintf("Error extracting sub from request: %v", err), nil)
+	}
+
+	log.Printf("Extracted sub: %s, email: %s", sub, email)
+
+	err = authentication_utils.RequireStudent(ctx, qc, sub, email)
+
+	if err != nil {
+		log.Printf("Error requiring student: %v", err)
+
+		return gateway_helpers.NewClientErrorGatewayResponse(fmt.Sprintf("Error requiring student: %v", err), nil)
+	}
+
+	// Get body and validate
+	body := RequestBodySchema{}
+	err = json.Unmarshal([]byte(request.Body), &body)
+
+	if err != nil {
+		log.Printf("Error unmarshalling request body: %v", err)
+
+		return gateway_helpers.NewClientErrorGatewayResponse(fmt.Sprintf("Error parsing request body: %v", err), nil)
+	}
+
+	if err = validate.Struct(body); err != nil {
+		log.Printf("Validation error: %v", err)
+
+		if errs, ok := err.(validator.ValidationErrors); ok {
+			resp := validation_error.FormatValidationError(errs)
+
+			return gateway_helpers.NewClientErrorGatewayResponse("Validation Error: Invalid request body.", resp)
+		}
+
+		return gateway_helpers.NewClientErrorGatewayResponse(fmt.Sprintf("Invalid request body: %v", err), nil)
+	}
+
+	insertClubQueries := []query_client.Query{
+		query_client.NewQuery("clubs/INSERT_club.sql", body.Name),
+		query_client.NewQuery("clubs/INSERT_club_info.sql", body.WebsiteURL, body.Description),
+	}
+
+	lastInsertId, err := qc.ExecInsertQuery(insertClubQueries, []bool{true})
+
+	if err != nil {
+		log.Printf("Error inserting club into database: %v", err)
+
+		return gateway_helpers.NewServerErrorGatewayResponse(fmt.Sprintf("Error inserting club into database: %v", err), nil)
+	}
+
+	response := map[string]any{
+		"clubId": lastInsertId,
+	}
+
+	return gateway_helpers.NewSuccessGatewayResponse("Successfully inserted club into database", response)
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/utils/query_client/queries/clubs/INSERT_club.sql
+++ b/utils/query_client/queries/clubs/INSERT_club.sql
@@ -1,0 +1,2 @@
+INSERT INTO clubs (name, fk_logo_id)
+VALUES (?, NULL);

--- a/utils/query_client/queries/clubs/INSERT_club_info.sql
+++ b/utils/query_client/queries/clubs/INSERT_club_info.sql
@@ -1,0 +1,2 @@
+INSERT INTO club_info (fk_club_id, website_url, description)
+VALUES (?, ?, ?);

--- a/utils/query_client/query_client.go
+++ b/utils/query_client/query_client.go
@@ -330,11 +330,11 @@ func (qc *QueryClient) ExecMulti(queries []Query) (results []sql.Result, err err
 // Therefore, this method expects len(queries) == len(needId) + 1.
 func (qc *QueryClient) ExecInsertQuery(queries []Query, needId []bool) (lastInsertId int64, err error) {
 	if len(queries) == 0 {
-		return 0, errors.New("IndexError: No queries provided")
+		return 0, errors.New("no queries provided")
 	}
 
 	if len(queries) != len(needId)+1 {
-		return 0, errors.New("IndexError: Length of queries and needId must be the same")
+		return 0, errors.New("length of queries and needId must be the same")
 	}
 
 	tx, err := qc.Conn.Beginx()
@@ -375,11 +375,14 @@ func (qc *QueryClient) ExecInsertQuery(queries []Query, needId []bool) (lastInse
 			return 0, err
 		}
 
+		var args []any
 		if needId[i] {
-			query.Args = append([]any{lastInsertId}, query.Args...)
+			args = append([]any{lastInsertId}, query.Args...)
+		} else {
+			args = query.Args
 		}
 
-		_, err = tx.Exec(queryString, query.Args...)
+		_, err = tx.Exec(queryString, args...)
 
 		if err != nil {
 			log.Printf("Error executing query from file %s: %v", query.Filepath, err)

--- a/utils/query_client/query_client.go
+++ b/utils/query_client/query_client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -314,6 +315,91 @@ func (qc *QueryClient) ExecMulti(queries []Query) (results []sql.Result, err err
 	err = tx.Commit()
 
 	return results, nil
+}
+
+// Execute multiple queries in sequence, each from their own file with optional args for placeholders in a transaction.
+// If any query fails, the transaction is aborted and rolled back.
+//
+// This variation of Exec uses the result of the first query to return the last inserted ID.
+// This is useful for cases where you need to insert a record and then use its ID for subsequent queries.
+//
+// Please note that the first query must be an INSERT statement that returns a valid last inserted ID.
+//
+// The needId slice indicates which queries require the last inserted ID as the first argument.
+// The first boolean in needId corresponds to the second query, the second boolean corresponds to the third query, and so on.
+// Therefore, this method expects len(queries) == len(needId) + 1.
+func (qc *QueryClient) ExecInsertQuery(queries []Query, needId []bool) (lastInsertId int64, err error) {
+	if len(queries) == 0 {
+		return 0, errors.New("IndexError: No queries provided")
+	}
+
+	if len(queries) != len(needId)+1 {
+		return 0, errors.New("IndexError: Length of queries and needId must be the same")
+	}
+
+	tx, err := qc.Conn.Beginx()
+
+	if err != nil {
+		log.Printf("Error beginning transaction: %v", err)
+		return 0, err
+	}
+
+	initialQueryString, err := loadSQLFromFile(queries[0].Filepath)
+	if err != nil {
+		log.Printf("Error loading SQL from file %s: %v", queries[0].Filepath, err)
+		tx.Rollback()
+		return 0, err
+	}
+
+	insertMainResult, err := tx.Exec(initialQueryString, queries[0].Args...)
+	if err != nil {
+		log.Printf("Error executing query from file %s: %v", queries[0].Filepath, err)
+		tx.Rollback()
+		return 0, err
+	}
+
+	lastInsertId, err = insertMainResult.LastInsertId()
+	if err != nil {
+		log.Printf("Error getting last inserted ID: %v", err)
+		tx.Rollback()
+		return 0, err
+	}
+
+	log.Printf("Executed query from file: %s", queries[0].Filepath)
+
+	for i, query := range queries[1:] {
+		queryString, err := loadSQLFromFile(query.Filepath)
+		if err != nil {
+			log.Printf("Error loading SQL from file %s: %v", query.Filepath, err)
+			tx.Rollback()
+			return 0, err
+		}
+
+		if needId[i] {
+			query.Args = append([]any{lastInsertId}, query.Args...)
+		}
+
+		_, err = tx.Exec(queryString, query.Args...)
+
+		if err != nil {
+			log.Printf("Error executing query from file %s: %v", query.Filepath, err)
+
+			tx.Rollback()
+
+			return 0, err
+		}
+
+		log.Printf("Executed query from file: %s", query.Filepath)
+	}
+
+	err = tx.Commit()
+
+	if err != nil {
+		log.Printf("Error committing transaction: %v", err)
+		return 0, err
+	}
+
+	return lastInsertId, nil
 }
 
 // DO NOT USE THIS METHOD. IT DOES NOT WORK PROPERLY.


### PR DESCRIPTION
Added two things with this PR:
- POST /clubs endpoint to create new clubs in the database
- insert method to QueryClient struct to support atomic insertions to the database (if any queries fail, they all fail).
  - It streamlines the creation of any single entity in the database by allowing queries after the first one to use the ID that was uploaded. Previously, we relied on using multiple Exec queries, which created duplicate dead data whenever a query failed.