### PR TITLE
feat: separate api stack into separate production and development api environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+CALLBACK_URLS=http://localhost:5173
+LOGOUT_URLS=http://localhost:5173

--- a/cdk-infrastructure.go
+++ b/cdk-infrastructure.go
@@ -95,6 +95,23 @@ func main() {
 		Authorizer: authorization.Authorizer,
 	})
 
+	stack.NewDevApiStack(app, "DevApiStack", &stack.DevApiStackProps{
+		Props: awscdk.StackProps{
+			Env:         env(),
+			Description: jsii.String("Stack for the development API Gateway and its routes"),
+		},
+
+		Vpc:                               network.Vpc,
+		LambdaSecretsManagerSecurityGroup: network.LambdaSecretsManagerSecurityGroup,
+		LambdaSecurityGroup:               database.LambdaSecurityGroup,
+		DbInstance:                        database.DbInstance,
+
+		Bucket: image.Bucket,
+
+		UserPool:  authentication.UserPool,
+		AppClient: authentication.AppClient,
+	})
+
 	stack.NewBastionStack(app, "BastionStack", &stack.BastionStackProps{
 		StackProps: awscdk.StackProps{
 			Env:         env(),
@@ -105,13 +122,11 @@ func main() {
 		DbSecurityGroup: database.DbSecurityGroup,
 	})
 
-	stubLambda := stack.NewStubLambdaStack(app, "StubLambdaStack", &stack.StubLambdaStackProps{
-		Props: awscdk.StackProps{
-			Env: env(),
-		},
-	})
-
-	_ = stubLambda
+	// stack.NewStubLambdaStack(app, "StubLambdaStack", &stack.StubLambdaStackProps{
+	// 	Props: awscdk.StackProps{
+	// 		Env: env(),
+	// 	},
+	// })
 
 	stack.NewDatabaseInitStack(app, "DatabaseInitStack", &stack.Props{
 		StackProps: awscdk.StackProps{

--- a/cdk-infrastructure.go
+++ b/cdk-infrastructure.go
@@ -23,25 +23,29 @@ func main() {
 
 	stack.NewFrontendStack(app, "FrontendStack", &stack.FrontendStackProps{
 		Props: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for the GWC website deployment"),
 		},
 	})
 
 	stack.NewFrontendHccStack(app, "FrontendHccStack", &stack.FrontendHccStackProps{
 		Props: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for the EMS website deployment"),
 		},
 	})
 
 	network := stack.NewNetworkStack(app, "NetworkStack", &stack.NetworkStackProps{
 		Props: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for all network infrastructure constructs"),
 		},
 	})
 
 	database := stack.NewDatabaseStack(app, "DatabaseStack", &stack.DatabaseStackProps{
 		Props: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for database constructs"),
 		},
 		Vpc: network.Vpc,
 	})
@@ -55,13 +59,15 @@ func main() {
 
 	authentication := stack.NewAuthenticationStack(app, "AuthenticationStack", &stack.AuthenticationStackProps{
 		Props: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for Cognito User Pool and App Client"),
 		},
 	})
 
 	authorization := stack.NewAuthorizationStack(app, "AuthorizationStack", &stack.AuthorizationStackProps{
 		Props: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for Cognito Authorizer for API Gateway"),
 		},
 
 		Vpc:                               network.Vpc,
@@ -73,9 +79,10 @@ func main() {
 		AppClient: authentication.AppClient,
 	})
 
-	stack.NewApiStack(app, "ApiStack", &stack.ApiStackProps{
+	stack.NewProdApiStack(app, "ProdApiStack", &stack.ProdApiStackProps{
 		Props: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for the production API Gateway and its routes"),
 		},
 
 		Vpc:                               network.Vpc,
@@ -90,7 +97,8 @@ func main() {
 
 	stack.NewBastionStack(app, "BastionStack", &stack.BastionStackProps{
 		StackProps: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for the RDS root access bastion EC2 instance."),
 		},
 
 		Vpc:             network.Vpc,
@@ -107,7 +115,8 @@ func main() {
 
 	stack.NewDatabaseInitStack(app, "DatabaseInitStack", &stack.Props{
 		StackProps: awscdk.StackProps{
-			Env: env(),
+			Env:         env(),
+			Description: jsii.String("Stack for the database table initialization lambdas. Should destroy if you see it since the lambda has already run."),
 		},
 
 		Vpc:                               network.Vpc,

--- a/gateway/integrations/club_thumbnails.go
+++ b/gateway/integrations/club_thumbnails.go
@@ -16,11 +16,12 @@ func GetClubThumbnailsIntegration(
 	vpc awsec2.IVpc,
 	lambdaToProxySG awsec2.ISecurityGroup,
 	s3Params gateway_parameters.S3PermissionsParameters,
+	deploymentTarget string,
 ) (awsapigatewayv2integrations.HttpLambdaIntegration, awscdklambdagoalpha.GoFunction) {
 	bucket := s3Params.Bucket
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubThumbnailFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetClubThumbnailsPresign"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubThumbnailFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetClubThumbnailsPresign" + deploymentTarget),
 		Entry:        jsii.String("lambda/api/clubs/thumbnails/get/get.go"),
 		Environment: &map[string]*string{
 			"S3_BUCKET": bucket.BucketName(),
@@ -41,11 +42,12 @@ func PostClubThumbnailsIntegration(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	s3Params gateway_parameters.S3PermissionsParameters,
+	deploymentTarget string,
 ) (awsapigatewayv2integrations.HttpLambdaIntegration, awscdklambdagoalpha.GoFunction) {
 	bucket := s3Params.Bucket
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostClubThumbnailPresignFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("PostClubThumbnailPresign"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostClubThumbnailPresignFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("PostClubThumbnailPresign" + deploymentTarget),
 		Entry:        jsii.String("lambda/api/clubs/thumbnails/post/post.go"),
 		Environment: &map[string]*string{
 			"S3_BUCKET": bucket.BucketName(),

--- a/gateway/integrations/clubs.go
+++ b/gateway/integrations/clubs.go
@@ -16,6 +16,7 @@ func GetClubsByVerification(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -23,8 +24,8 @@ func GetClubsByVerification(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubsByVerificationFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetClubsByVerification"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubsByVerificationFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetClubsByVerification" + deploymentTarget),
 		Description:  jsii.String("Get only verified clubs if verified is true, else get all clubs"),
 		Entry:        jsii.String("lambda/api/clubs/get.go"),
 		Environment: &map[string]*string{
@@ -43,7 +44,7 @@ func GetClubsByVerification(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetClubsByVerificationIntegration"),
+		jsii.String("GetClubsByVerificationIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
@@ -56,6 +57,7 @@ func GetClubById(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -63,8 +65,8 @@ func GetClubById(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubByIdFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetClubsById"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubByIdFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetClubsById" + deploymentTarget),
 		Description:  jsii.String("Get by its clubId"),
 		Entry:        jsii.String("lambda/api/clubs/clubId/get.go"),
 		Environment: &map[string]*string{
@@ -83,7 +85,7 @@ func GetClubById(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetClubByIdIntegration"),
+		jsii.String("GetClubByIdIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
@@ -96,6 +98,7 @@ func GetClubEventsByPeriod(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -103,8 +106,8 @@ func GetClubEventsByPeriod(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubEventsByPeriodFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetClubEventsByPeriod"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetClubEventsByPeriodFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetClubEventsByPeriod" + deploymentTarget),
 		Description:  jsii.String("Get posted events from a specific club between start and end date"),
 		Entry:        jsii.String("lambda/api/clubs/clubId/events/get.go"),
 		Environment: &map[string]*string{
@@ -123,7 +126,7 @@ func GetClubEventsByPeriod(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetClubEventsByPeriodIntegration"),
+		jsii.String("GetClubEventsByPeriodIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
@@ -136,6 +139,7 @@ func PostNewClubEvent(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -143,8 +147,8 @@ func PostNewClubEvent(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostNewClubEventFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("PostNewClubEvent"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostNewClubEventFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("PostNewClubEvent" + deploymentTarget),
 		Description:  jsii.String("Post a new event to a specific club"),
 		Entry:        jsii.String("lambda/api/clubs/clubId/events/post/post.go"),
 		Environment: &map[string]*string{
@@ -163,7 +167,7 @@ func PostNewClubEvent(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("PostNewClubEventIntegration"),
+		jsii.String("PostNewClubEventIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
@@ -175,6 +179,7 @@ func PostNewClub(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -182,8 +187,8 @@ func PostNewClub(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("CreateNewClubFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("CreateNewClubFunction"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("CreateNewClubFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("CreateNewClubFunction" + deploymentTarget),
 		Description:  jsii.String("Create a new club"),
 		Entry:        jsii.String("lambda/api/clubs/post/post.go"),
 		Environment: &map[string]*string{
@@ -202,7 +207,7 @@ func PostNewClub(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("CreateNewClubIntegration"),
+		jsii.String("CreateNewClubIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)

--- a/gateway/integrations/event_images.go
+++ b/gateway/integrations/event_images.go
@@ -1,6 +1,7 @@
 package integrations
 
 import (
+	gateway_helpers "cdk-infrastructure/gateway/helpers"
 	gateway_parameters "cdk-infrastructure/gateway/parameters"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
@@ -16,18 +17,21 @@ func GetEventImagesIntegration(
 	vpc awsec2.IVpc,
 	s3Params gateway_parameters.S3PermissionsParameters,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
-) (awsapigatewayv2integrations.HttpLambdaIntegration, awscdklambdagoalpha.GoFunction) {
+	deploymentTarget string,
+) awsapigatewayv2integrations.HttpLambdaIntegration {
 	bucket := s3Params.Bucket
 
 	dbSecretArn := dbParams.Secret.SecretArn()
+	dbInstance := dbParams.DbInstance
+	dbSecret := dbParams.Secret
 	dbHost := jsii.String(dbParams.DbHost)
 	dbName := jsii.String(dbParams.DbName)
 
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetEventImagesPresignFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetClubEventImagesPresign"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetEventImagesPresignFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetClubEventImagesPresign" + deploymentTarget),
 		Entry:        jsii.String("lambda/api/clubs/events/images/get/get.go"),
 		Environment: &map[string]*string{
 			"S3_BUCKET":     bucket.BucketName(),
@@ -43,20 +47,28 @@ func GetEventImagesIntegration(
 		Timeout: awscdk.Duration_Minutes(jsii.Number(1)),
 	})
 
+	gateway_helpers.GrantRdsAccessToLambda(function, dbInstance, dbSecret)
+	gateway_helpers.GrantS3AccessToLambda(function, bucket, "events/*", true, false)
+
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetEventImagePresignIntegration"),
+		jsii.String("GetEventImagePresignIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
 
-	return integration, function
+	return integration
 }
 
-func PostEventImagesIntegration(stack awscdk.Stack, vpc awsec2.IVpc, s3Params gateway_parameters.S3PermissionsParameters) (awsapigatewayv2integrations.HttpLambdaIntegration, awscdklambdagoalpha.GoFunction) {
+func PostEventImagesIntegration(
+	stack awscdk.Stack,
+	vpc awsec2.IVpc,
+	s3Params gateway_parameters.S3PermissionsParameters,
+	deploymentTarget string,
+) awsapigatewayv2integrations.HttpLambdaIntegration {
 	bucket := s3Params.Bucket
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostEventImagesPresignFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("PostClubEventImagesPresign"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostEventImagesPresignFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("PostClubEventImagesPresign" + deploymentTarget),
 		Entry:        jsii.String("lambda/api/clubs/events/images/post/post.go"),
 		Environment: &map[string]*string{
 			"S3_BUCKET": bucket.BucketName(),
@@ -64,29 +76,35 @@ func PostEventImagesIntegration(stack awscdk.Stack, vpc awsec2.IVpc, s3Params ga
 		Vpc: vpc,
 	})
 
+	gateway_helpers.GrantS3AccessToLambda(function, bucket, "events/*", true, false)
+
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("PostEventImagePresignIntegration"),
+		jsii.String("PostEventImagePresignIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
 
-	return integration, function
+	return integration
 }
 
 func ConfirmEventImagesIntegration(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
-) (awsapigatewayv2integrations.HttpLambdaIntegration, awscdklambdagoalpha.GoFunction) {
+	deploymentTarget string,
+) awsapigatewayv2integrations.HttpLambdaIntegration {
 	dbSecretArn := dbParams.Secret.SecretArn()
 	dbHost := jsii.String(dbParams.DbHost)
 	dbName := jsii.String(dbParams.DbName)
 
+	dbInstance := dbParams.DbInstance
+	dbSecret := dbParams.Secret
+
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("ConfirmEventImagesFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("ConfirmClubEventImages"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("ConfirmEventImagesFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("ConfirmClubEventImages" + deploymentTarget),
 		Entry:        jsii.String("lambda/api/clubs/events/images/confirm/post.go"),
 		Environment: &map[string]*string{
 			"DB_SECRET_ARN": dbSecretArn,
@@ -101,11 +119,13 @@ func ConfirmEventImagesIntegration(
 		Timeout: awscdk.Duration_Minutes(jsii.Number(1)),
 	})
 
+	gateway_helpers.GrantRdsAccessToLambda(function, dbInstance, dbSecret)
+
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("ConfirmEventImageIntegration"),
+		jsii.String("ConfirmEventImageIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
 
-	return integration, function
+	return integration
 }

--- a/gateway/integrations/event_images.go
+++ b/gateway/integrations/event_images.go
@@ -76,7 +76,7 @@ func PostEventImagesIntegration(
 		Vpc: vpc,
 	})
 
-	gateway_helpers.GrantS3AccessToLambda(function, bucket, "events/*", true, false)
+	gateway_helpers.GrantS3AccessToLambda(function, bucket, "events/*", false, true)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
 		jsii.String("PostEventImagePresignIntegration"+deploymentTarget),

--- a/gateway/integrations/event_thumbnails.go
+++ b/gateway/integrations/event_thumbnails.go
@@ -1,6 +1,7 @@
 package integrations
 
 import (
+	gateway_helpers "cdk-infrastructure/gateway/helpers"
 	gateway_parameters "cdk-infrastructure/gateway/parameters"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
@@ -46,11 +47,12 @@ func PostEventThumbnailsIntegration(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	s3Params gateway_parameters.S3PermissionsParameters,
-) (awsapigatewayv2integrations.HttpLambdaIntegration, awscdklambdagoalpha.GoFunction) {
+	deploymentTarget string,
+) awsapigatewayv2integrations.HttpLambdaIntegration {
 	bucket := s3Params.Bucket
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostEventThumbnailsPresignFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("PostClubEventThumbnailsPostPresign"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostEventThumbnailsPresignFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("PostClubEventThumbnailsPostPresign" + deploymentTarget),
 		Entry:        jsii.String("lambda/api/clubs/events/thumbnails/post/post.go"),
 		Environment: &map[string]*string{
 			"S3_BUCKET": bucket.BucketName(),
@@ -58,11 +60,13 @@ func PostEventThumbnailsIntegration(
 		Vpc: vpc,
 	})
 
+	gateway_helpers.GrantS3AccessToLambda(function, bucket, "events/*/thumbnails/*", false, true)
+
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("PostEventThumbnailsPresignIntegration"),
+		jsii.String("PostEventThumbnailsPresignIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
 
-	return integration, function
+	return integration
 }

--- a/gateway/integrations/events.go
+++ b/gateway/integrations/events.go
@@ -16,6 +16,7 @@ func GetEventsByPeriod(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -23,8 +24,8 @@ func GetEventsByPeriod(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetEventsByPeriodFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetEventsByPeriod"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetEventsByPeriodFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetEventsByPeriod" + deploymentTarget),
 		Description:  jsii.String("Get posted events between start and end date"),
 		Entry:        jsii.String("lambda/api/events/get.go"),
 		Environment: &map[string]*string{
@@ -43,7 +44,7 @@ func GetEventsByPeriod(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetEventsByPeriodIntegration"),
+		jsii.String("GetEventsByPeriodIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
@@ -56,6 +57,7 @@ func GetEventById(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -63,8 +65,8 @@ func GetEventById(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetEventByIdFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetEventById"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetEventByIdFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetEventById" + deploymentTarget),
 		Description:  jsii.String("Get event by ID"),
 		Entry:        jsii.String("lambda/api/events/eventId/get.go"),
 		Environment: &map[string]*string{
@@ -83,7 +85,7 @@ func GetEventById(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetEventByIdIntegration"),
+		jsii.String("GetEventByIdIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)

--- a/gateway/integrations/students.go
+++ b/gateway/integrations/students.go
@@ -16,6 +16,7 @@ func GetStudentMeBySub(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -23,8 +24,8 @@ func GetStudentMeBySub(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetStudentMeFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetStudentMe"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetStudentMeFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetStudentMe" + deploymentTarget),
 		Description:  jsii.String("Returns the student data associated with the sub from jwt"),
 		Entry:        jsii.String("./lambda/api/me/get.go"),
 		Environment: &map[string]*string{
@@ -43,7 +44,7 @@ func GetStudentMeBySub(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetStudentMeIntegration"),
+		jsii.String("GetStudentMeIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
@@ -56,6 +57,7 @@ func GetMyClubs(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -63,8 +65,8 @@ func GetMyClubs(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetMyClubsFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetMyClubs"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetMyClubsFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetMyClubs" + deploymentTarget),
 		Description:  jsii.String("Returns clubs of the student of asoociated jwt"),
 		Entry:        jsii.String("lambda/api/me/clubs/get.go"),
 		Environment: &map[string]*string{
@@ -83,7 +85,7 @@ func GetMyClubs(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetMyClubsIntegration"),
+		jsii.String("GetMyClubsIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)
@@ -96,6 +98,7 @@ func GetMyEvents(
 	stack awscdk.Stack,
 	vpc awsec2.IVpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) awsapigatewayv2integrations.HttpLambdaIntegration {
 	host := dbParams.DbHost
 	dbName := dbParams.DbName
@@ -103,8 +106,8 @@ func GetMyEvents(
 	lambdaSG := dbParams.LambdaSG
 	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
 
-	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetMyEventsFunction"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("GetMyEvents"),
+	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetMyEventsFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("GetMyEvents" + deploymentTarget),
 		Description:  jsii.String("Returns events from clubs that a user has joined"),
 		Entry:        jsii.String("lambda/api/me/events/get.go"),
 		Environment: &map[string]*string{
@@ -123,7 +126,7 @@ func GetMyEvents(
 	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("GetMyEventsIntegration"),
+		jsii.String("GetMyEventsIntegration"+deploymentTarget),
 		function,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)

--- a/gateway/integrations/students.go
+++ b/gateway/integrations/students.go
@@ -67,7 +67,7 @@ func GetMyClubs(
 
 	function := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("GetMyClubsFunction"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
 		FunctionName: jsii.String("GetMyClubs" + deploymentTarget),
-		Description:  jsii.String("Returns clubs of the student of asoociated jwt"),
+		Description:  jsii.String("Returns clubs of the student of associated jwt"),
 		Entry:        jsii.String("lambda/api/me/clubs/get.go"),
 		Environment: &map[string]*string{
 			"DB_SECRET_ARN": arn,

--- a/gateway/integrations/test_ping.go
+++ b/gateway/integrations/test_ping.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/jsii-runtime-go"
 )
 
-func PingTestIntegration(stack awscdk.Stack) awsapigatewayv2integrations.HttpLambdaIntegration {
-	pingFunc := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("Ping Function"), &awscdklambdagoalpha.GoFunctionProps{
-		FunctionName: jsii.String("PingTest"),
+func PingTestIntegration(stack awscdk.Stack, deploymentTarget string) awsapigatewayv2integrations.HttpLambdaIntegration {
+	pingFunc := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("Ping Function"+deploymentTarget), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("PingTest" + deploymentTarget),
 		Entry:        jsii.String("./lambda/api/test/ping/main.go"),
 	})
 
 	integration := awsapigatewayv2integrations.NewHttpLambdaIntegration(
-		jsii.String("PingLambdaIntegration"),
+		jsii.String("PingLambdaIntegration"+deploymentTarget),
 		pingFunc,
 		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
 	)

--- a/gateway/routes/club_image_routes.go
+++ b/gateway/routes/club_image_routes.go
@@ -22,6 +22,7 @@ func ClubImageRoutes(
 	vpc awsec2.Vpc,
 	s3Params gateway_parameters.S3PermissionsParameters,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) {
 	// proxySg := dbParams.RdsProxySG
 	// dbInstance := dbParams.DbInstance
@@ -40,7 +41,7 @@ func ClubImageRoutes(
 	// })
 
 	// POST /clubs/{clubId}/thumbnails
-	postThumbnailsInt, postThumbnailsFunc := integrations.PostClubThumbnailsIntegration(stack, vpc, s3Params)
+	postThumbnailsInt, postThumbnailsFunc := integrations.PostClubThumbnailsIntegration(stack, vpc, s3Params, deploymentTarget)
 	gateway_helpers.GrantS3AccessToLambda(postThumbnailsFunc, bucket, "clubs/*/thumbnails/*", false, true)
 
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{

--- a/gateway/routes/club_routes.go
+++ b/gateway/routes/club_routes.go
@@ -20,6 +20,7 @@ func ClubRoutes(
 	vpc awsec2.Vpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
 	authorizer awsapigatewayv2.IHttpRouteAuthorizer,
+	deploymentTarget string,
 ) {
 	// GET /clubs
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
@@ -27,7 +28,7 @@ func ClubRoutes(
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_GET,
 		},
-		Integration: integrations.GetClubsByVerification(stack, vpc, dbParams),
+		Integration: integrations.GetClubsByVerification(stack, vpc, dbParams, deploymentTarget),
 	})
 
 	// Get /clubs/{clubId}
@@ -36,7 +37,7 @@ func ClubRoutes(
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_GET,
 		},
-		Integration: integrations.GetClubById(stack, vpc, dbParams),
+		Integration: integrations.GetClubById(stack, vpc, dbParams, deploymentTarget),
 	})
 
 	// GET /clubs/{clubId}/events
@@ -45,7 +46,7 @@ func ClubRoutes(
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_GET,
 		},
-		Integration: integrations.GetClubEventsByPeriod(stack, vpc, dbParams),
+		Integration: integrations.GetClubEventsByPeriod(stack, vpc, dbParams, deploymentTarget),
 	})
 
 	// POST /clubs/{clubId}/events
@@ -54,7 +55,7 @@ func ClubRoutes(
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_POST,
 		},
-		Integration: integrations.PostNewClubEvent(stack, vpc, dbParams),
+		Integration: integrations.PostNewClubEvent(stack, vpc, dbParams, deploymentTarget),
 		Authorizer:  authorizer,
 	})
 
@@ -64,7 +65,7 @@ func ClubRoutes(
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_POST,
 		},
-		Integration: integrations.PostNewClub(stack, vpc, dbParams),
+		Integration: integrations.PostNewClub(stack, vpc, dbParams, deploymentTarget),
 		Authorizer:  authorizer,
 	})
 }

--- a/gateway/routes/event_image_routes.go
+++ b/gateway/routes/event_image_routes.go
@@ -1,7 +1,6 @@
 package gateway_routes
 
 import (
-	gateway_helpers "cdk-infrastructure/gateway/helpers"
 	"cdk-infrastructure/gateway/integrations"
 	gateway_parameters "cdk-infrastructure/gateway/parameters"
 
@@ -30,62 +29,46 @@ func EventImageRoutes(
 	vpc awsec2.Vpc,
 	s3Params gateway_parameters.S3PermissionsParameters,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
 ) {
-	dbInstance := dbParams.DbInstance
-	dbSecret := dbParams.Secret
-	bucket := s3Params.Bucket
-
 	/// Event Images
 	// GET /clubs/{clubId}/events/{eventId}/images
-	getEventImagesInt, getEventImagesFn := integrations.GetEventImagesIntegration(stack, vpc, s3Params, dbParams)
-	gateway_helpers.GrantRdsAccessToLambda(getEventImagesFn, dbInstance, dbSecret)
-	gateway_helpers.GrantS3AccessToLambda(getEventImagesFn, bucket, "events/*", true, false)
-
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path: jsii.String("/clubs/{clubId}/events/{eventId}/images"),
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_GET,
 		},
-		Integration: getEventImagesInt,
+		Integration: integrations.GetEventImagesIntegration(stack, vpc, s3Params, dbParams, deploymentTarget),
 	})
 
 	// POST /clubs/{clubId}/events/{eventId}/images
-	postEventImagesInt, postEventImagesFn := integrations.PostEventImagesIntegration(stack, vpc, s3Params)
-	gateway_helpers.GrantS3AccessToLambda(postEventImagesFn, bucket, "events/*", false, true)
-
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path: jsii.String("/clubs/{clubId}/events/{eventId}/images"),
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_POST,
 			awsapigatewayv2.HttpMethod_OPTIONS,
 		},
-		Integration: postEventImagesInt,
+		Integration: integrations.PostEventImagesIntegration(stack, vpc, s3Params, deploymentTarget),
 	})
 
 	// POST /clubs/{clubId}/events/{eventId}/images/confirm
-	confirmEventImagesInt, confirmEventImagesFn := integrations.ConfirmEventImagesIntegration(stack, vpc, dbParams)
-	gateway_helpers.GrantRdsAccessToLambda(confirmEventImagesFn, dbInstance, dbSecret)
-
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path: jsii.String("/clubs/{clubId}/events/{eventId}/images/confirm"),
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_POST,
 			awsapigatewayv2.HttpMethod_OPTIONS,
 		},
-		Integration: confirmEventImagesInt,
+		Integration: integrations.ConfirmEventImagesIntegration(stack, vpc, dbParams, deploymentTarget),
 	})
 
 	// Event Thumbnails
 	// POST /clubs/{clubId}/events/{eventId}/thumbnails
-	postEventThumbnailsInt, postEventImagesFn := integrations.PostEventThumbnailsIntegration(stack, vpc, s3Params)
-	gateway_helpers.GrantS3AccessToLambda(postEventImagesFn, bucket, "events/*/thumbnails/*", false, true)
-
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path: jsii.String("/clubs/{clubId}/events/{eventId}/thumbnails"),
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_POST,
 			awsapigatewayv2.HttpMethod_OPTIONS,
 		},
-		Integration: postEventThumbnailsInt,
+		Integration: integrations.PostEventThumbnailsIntegration(stack, vpc, s3Params, deploymentTarget),
 	})
 }

--- a/gateway/routes/event_routes.go
+++ b/gateway/routes/event_routes.go
@@ -16,14 +16,20 @@ import (
 //
 // GET /events?startDate={startDate}&endDate={endDate}
 // GET /events/{eventId}
-func PublicEventRoutes(httpApi awsapigatewayv2.HttpApi, stack awscdk.Stack, vpc awsec2.Vpc, dbParams gateway_parameters.DatabaseConnectionParameters) {
+func PublicEventRoutes(
+	httpApi awsapigatewayv2.HttpApi,
+	stack awscdk.Stack,
+	vpc awsec2.Vpc,
+	dbParams gateway_parameters.DatabaseConnectionParameters,
+	deploymentTarget string,
+) {
 	// /events?startDate={startDate}&endDate={endDate}
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path: jsii.String("/events"),
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_GET,
 		},
-		Integration: integrations.GetEventsByPeriod(stack, vpc, dbParams),
+		Integration: integrations.GetEventsByPeriod(stack, vpc, dbParams, deploymentTarget),
 	})
 
 	// /events/{eventId}
@@ -32,6 +38,6 @@ func PublicEventRoutes(httpApi awsapigatewayv2.HttpApi, stack awscdk.Stack, vpc 
 		Methods: &[]awsapigatewayv2.HttpMethod{
 			awsapigatewayv2.HttpMethod_GET,
 		},
-		Integration: integrations.GetEventById(stack, vpc, dbParams),
+		Integration: integrations.GetEventById(stack, vpc, dbParams, deploymentTarget),
 	})
 }

--- a/gateway/routes/student_routes.go
+++ b/gateway/routes/student_routes.go
@@ -20,12 +20,13 @@ func StudentMeRoutes(
 	vpc awsec2.Vpc,
 	dbParams gateway_parameters.DatabaseConnectionParameters,
 	Authorizer awsapigatewayv2.IHttpRouteAuthorizer,
+	deploymentTarget string,
 ) {
 	// GET /me route
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path:        jsii.String("/me"),
 		Methods:     &[]awsapigatewayv2.HttpMethod{awsapigatewayv2.HttpMethod_GET},
-		Integration: integrations.GetStudentMeBySub(stack, vpc, dbParams),
+		Integration: integrations.GetStudentMeBySub(stack, vpc, dbParams, deploymentTarget),
 		Authorizer:  Authorizer,
 	})
 
@@ -33,7 +34,7 @@ func StudentMeRoutes(
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path:        jsii.String("/me/clubs"),
 		Methods:     &[]awsapigatewayv2.HttpMethod{awsapigatewayv2.HttpMethod_GET},
-		Integration: integrations.GetMyClubs(stack, vpc, dbParams),
+		Integration: integrations.GetMyClubs(stack, vpc, dbParams, deploymentTarget),
 		Authorizer:  Authorizer,
 	})
 
@@ -41,7 +42,7 @@ func StudentMeRoutes(
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path:        jsii.String("/me/events"),
 		Methods:     &[]awsapigatewayv2.HttpMethod{awsapigatewayv2.HttpMethod_GET},
-		Integration: integrations.GetMyEvents(stack, vpc, dbParams),
+		Integration: integrations.GetMyEvents(stack, vpc, dbParams, deploymentTarget),
 		Authorizer:  Authorizer,
 	})
 }

--- a/gateway/routes/test_routes.go
+++ b/gateway/routes/test_routes.go
@@ -12,10 +12,10 @@ import (
 // Routes:
 //
 // - GET /health: A simple health check endpoint that returns a "Server Running" response.
-func TestRoutes(httpApi awsapigatewayv2.HttpApi, stack awscdk.Stack) {
+func TestRoutes(httpApi awsapigatewayv2.HttpApi, stack awscdk.Stack, deploymentTarget string) {
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path:        jsii.String("/health"),
 		Methods:     &[]awsapigatewayv2.HttpMethod{awsapigatewayv2.HttpMethod_GET},
-		Integration: integrations.PingTestIntegration(stack),
+		Integration: integrations.PingTestIntegration(stack, deploymentTarget),
 	})
 }

--- a/gateway/stagingApi/README.md
+++ b/gateway/stagingApi/README.md
@@ -1,0 +1,13 @@
+# Staging API Directory
+
+Created as a part of the separation of the production and staging API environments, I plan to put any routing related to the development API Gateway here.
+
+This includes testing routes, routes that are deployed to the testing API gateway environment, ect.
+
+This is under the gateway directory because I still want access to the helpers used for the production API.
+
+\- Anthony
+
+**Created 12/2/25**
+<br>
+**Last Updated 12/2/25**

--- a/gateway/stagingApi/README.md
+++ b/gateway/stagingApi/README.md
@@ -1,8 +1,8 @@
 # Staging API Directory
 
-Created as a part of the separation of the production and staging API environments, I plan to put any routing related to the development API Gateway here.
+Created as a part of the separation of the production and development API environments, I plan to put any routing related to the dev API Gateway here.
 
-This includes testing routes, routes that are deployed to the testing API gateway environment, ect.
+This includes testing routes, routes that are deployed to the testing API gateway environment, etc.
 
 This is under the gateway directory because I still want access to the helpers used for the production API.
 

--- a/internal/stack/authentication.go
+++ b/internal/stack/authentication.go
@@ -81,8 +81,6 @@ func NewAuthenticationStack(scope constructs.Construct, id string, props *Authen
 		Value: domain.BaseUrl(&awscognito.BaseUrlOptions{}),
 	})
 
-	//
-
 	googleProvider := awscognito.NewUserPoolIdentityProviderGoogle(stack, jsii.String("GoogleIdP"), &awscognito.UserPoolIdentityProviderGoogleProps{
 		UserPool:     userPool,
 		ClientId:     jsii.String(os.Getenv("GOOGLE_CLIENT_ID")),

--- a/internal/stack/database.go
+++ b/internal/stack/database.go
@@ -78,10 +78,11 @@ func NewDatabaseStack(scope constructs.Construct, id string, props *DatabaseStac
 		Credentials:         awsrds.Credentials_FromGeneratedSecret(jsii.String("dbadmin"), nil),
 		AllocatedStorage:    jsii.Number(20),
 		MaxAllocatedStorage: jsii.Number(100),
-		BackupRetention:     awscdk.Duration_Days(jsii.Number(7)),
-		MultiAz:             jsii.Bool(false),
-		RemovalPolicy:       awscdk.RemovalPolicy_DESTROY,
-		DeletionProtection:  jsii.Bool(false),
+		BackupRetention:     awscdk.Duration_Days(jsii.Number(1)),
+		// BackupRetention:     awscdk.Duration_Days(jsii.Number(7)), // This gave me issues with free tier
+		MultiAz:            jsii.Bool(false),
+		RemovalPolicy:      awscdk.RemovalPolicy_DESTROY,
+		DeletionProtection: jsii.Bool(false),
 	})
 
 	// Saving costs

--- a/internal/stack/database_init.go
+++ b/internal/stack/database_init.go
@@ -51,7 +51,7 @@ func NewDatabaseInitStack(scope constructs.Construct, id string, props *Props) {
 				lambdaSecurityGroup,
 			},
 			LogGroup: awslogs.NewLogGroup(stack, jsii.String("DatabaseInitLogGroup"), &awslogs.LogGroupProps{
-				LogGroupName:  jsii.String("Database Initializer Logs"),
+				LogGroupName:  jsii.String("DatabaseInitializerLogs"),
 				LogGroupClass: awslogs.LogGroupClass_STANDARD,
 				Retention:     awslogs.RetentionDays_ONE_WEEK,
 			}),

--- a/internal/stack/developmentApi.go
+++ b/internal/stack/developmentApi.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/jsii-runtime-go"
 )
 
-type ProdApiStackProps struct {
+type DevApiStackProps struct {
 	Props awscdk.StackProps
 
 	Vpc                               awsec2.Vpc
@@ -29,15 +29,15 @@ type ProdApiStackProps struct {
 	Authorizer awsapigatewayv2.IHttpRouteAuthorizer
 }
 
-func NewProdApiStack(scope constructs.Construct, id string, props *ProdApiStackProps) awscdk.Stack {
+func NewDevApiStack(scope constructs.Construct, id string, props *DevApiStackProps) awscdk.Stack {
 	var sprops awscdk.StackProps
 	if props != nil {
 		sprops = props.Props
 	}
 	stack := awscdk.NewStack(scope, &id, &sprops)
 
-	httpApi := awsapigatewayv2.NewHttpApi(stack, jsii.String("ClubEventApiProd"), &awsapigatewayv2.HttpApiProps{
-		ApiName: jsii.String("ClubEventApiProd"),
+	httpApi := awsapigatewayv2.NewHttpApi(stack, jsii.String("ClubEventApiDev"), &awsapigatewayv2.HttpApiProps{
+		ApiName: jsii.String("ClubEventApiDev"),
 		CorsPreflight: &awsapigatewayv2.CorsPreflightOptions{
 			AllowHeaders: &[]*string{
 				jsii.String("*"),
@@ -54,7 +54,7 @@ func NewProdApiStack(scope constructs.Construct, id string, props *ProdApiStackP
 		},
 	})
 
-	const databaseName string = "PRODUCTION"
+	const databaseName string = "STAGING"
 
 	vpc := props.Vpc
 
@@ -71,7 +71,7 @@ func NewProdApiStack(scope constructs.Construct, id string, props *ProdApiStackP
 		DbName:                   databaseName,
 	}
 
-	deploymentTarget := "Prod"
+	deploymentTarget := "Dev"
 
 	authorizer := props.Authorizer
 

--- a/internal/stack/developmentApi.go
+++ b/internal/stack/developmentApi.go
@@ -1,13 +1,20 @@
 package stack
 
 import (
+	gateway_helpers "cdk-infrastructure/gateway/helpers"
 	gateway_parameters "cdk-infrastructure/gateway/parameters"
 	gateway_routes "cdk-infrastructure/gateway/routes"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2" // core
+	"github.com/aws/aws-cdk-go/awscdk/v2/awsapigatewayv2authorizers"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awscognito"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsec2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awsiam"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsrds"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awss3"
+	cr "github.com/aws/aws-cdk-go/awscdk/v2/customresources"
+	"github.com/aws/aws-cdk-go/awscdklambdagoalpha/v2"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsapigatewayv2"
 
@@ -26,7 +33,8 @@ type DevApiStackProps struct {
 	BucketName *string
 	Bucket     awss3.Bucket
 
-	Authorizer awsapigatewayv2.IHttpRouteAuthorizer
+	UserPool  awscognito.IUserPool
+	AppClient awscognito.IUserPoolClient
 }
 
 func NewDevApiStack(scope constructs.Construct, id string, props *DevApiStackProps) awscdk.Stack {
@@ -58,6 +66,17 @@ func NewDevApiStack(scope constructs.Construct, id string, props *DevApiStackPro
 
 	vpc := props.Vpc
 
+	authorizer := createDevApiAuthorizer(
+		stack,
+		props.Vpc,
+		props.LambdaSecurityGroup,
+		props.LambdaSecretsManagerSecurityGroup,
+		props.DbInstance,
+		props.UserPool,
+		props.AppClient,
+		databaseName,
+	)
+
 	s3Params := gateway_parameters.S3PermissionsParameters{
 		Bucket: props.Bucket,
 	}
@@ -72,8 +91,6 @@ func NewDevApiStack(scope constructs.Construct, id string, props *DevApiStackPro
 	}
 
 	deploymentTarget := "Dev"
-
-	authorizer := props.Authorizer
 
 	gateway_routes.TestRoutes(httpApi, stack, deploymentTarget)
 
@@ -94,4 +111,93 @@ func NewDevApiStack(scope constructs.Construct, id string, props *DevApiStackPro
 	})
 
 	return stack
+}
+
+func createDevApiAuthorizer(
+	stack awscdk.Stack,
+	vpc awsec2.Vpc,
+	lambdaSecurityGroup awsec2.SecurityGroup,
+	lambdaSecretsManagerSecurityGroup awsec2.SecurityGroup,
+	dbInstance awsrds.DatabaseInstance,
+	userPool awscognito.IUserPool,
+	appClient awscognito.IUserPoolClient,
+	databaseName string,
+) awsapigatewayv2.IHttpRouteAuthorizer {
+	postConfirmFunction := awscdklambdagoalpha.NewGoFunction(stack, jsii.String("PostConfirmUserUpsertFunctionDev"), &awscdklambdagoalpha.GoFunctionProps{
+		FunctionName: jsii.String("PostConfirmUserUpsertDev"),
+		Description:  jsii.String("Upsert Cognito User to DB"),
+		Entry:        jsii.String("./lambda/internal/auth/postConfirm/upsert.go"),
+		Environment: &map[string]*string{
+			"DB_SECRET_ARN": dbInstance.Secret().SecretArn(),
+			"DB_HOST":       jsii.String(*dbInstance.DbInstanceEndpointAddress()),
+			"DB_NAME":       jsii.String(databaseName),
+		},
+		Vpc:     vpc,
+		Timeout: awscdk.Duration_Minutes(jsii.Number(1)),
+		SecurityGroups: &[]awsec2.ISecurityGroup{
+			lambdaSecurityGroup,
+			lambdaSecretsManagerSecurityGroup,
+		},
+	})
+
+	gateway_helpers.GrantRdsAccessToLambda(postConfirmFunction, dbInstance, dbInstance.Secret())
+
+	// allow Cognito to invoke your Lambda
+	postConfirmFunction.AddPermission(jsii.String("AllowCognitoInvoke"), &awslambda.Permission{
+		Principal: awsiam.NewServicePrincipal(jsii.String("cognito-idp.amazonaws.com"), nil),
+		SourceArn: userPool.UserPoolArn(),
+	})
+
+	physID := "Wire-" + *userPool.UserPoolId()
+
+	onUp := &cr.AwsSdkCall{
+		Service: jsii.String("CognitoIdentityServiceProvider"), // <<< v2 name
+		Action:  jsii.String("updateUserPool"),
+		Parameters: &map[string]interface{}{
+			"UserPoolId": *userPool.UserPoolId(),
+			"LambdaConfig": map[string]interface{}{
+				"PostConfirmation": postConfirmFunction.FunctionArn(),
+				// include if you want every login too:
+				"PostAuthentication": postConfirmFunction.FunctionArn(),
+			},
+		},
+		PhysicalResourceId: cr.PhysicalResourceId_Of(jsii.String(physID)),
+	}
+
+	onDel := &cr.AwsSdkCall{
+		Service: jsii.String("CognitoIdentityServiceProvider"), // <<< v2 name
+		Action:  jsii.String("updateUserPool"),
+		Parameters: &map[string]interface{}{
+			"UserPoolId":   *userPool.UserPoolId(),
+			"LambdaConfig": map[string]interface{}{}, // clears triggers
+		},
+		PhysicalResourceId:       cr.PhysicalResourceId_Of(jsii.String(physID)),
+		IgnoreErrorCodesMatching: jsii.String(".*ResourceNotFound.*"),
+	}
+
+	// Scope permissions if you want (instead of ANY_RESOURCE)
+	policy := awsiam.NewPolicyStatement(&awsiam.PolicyStatementProps{
+		Actions:   &[]*string{jsii.String("cognito-idp:UpdateUserPool")},
+		Resources: &[]*string{userPool.UserPoolArn()},
+	})
+
+	cr.NewAwsCustomResource(stack, jsii.String("WireCognitoTriggers"), &cr.AwsCustomResourceProps{
+		Policy:              cr.AwsCustomResourcePolicy_FromStatements(&[]awsiam.PolicyStatement{policy}),
+		OnCreate:            onUp,
+		OnUpdate:            onUp,
+		OnDelete:            onDel,
+		InstallLatestAwsSdk: jsii.Bool(false), // use SDK v2
+	})
+
+	authorizer := awsapigatewayv2authorizers.NewHttpUserPoolAuthorizer(
+		jsii.String("CognitoJwtDev"),
+		userPool,
+		&awsapigatewayv2authorizers.HttpUserPoolAuthorizerProps{
+			UserPoolClients: &[]awscognito.IUserPoolClient{appClient},
+			// Optional: AuthorizerName: jsii.String("CognitoJwtAuthorizer"),
+			// Optional: ResultsCacheTtl: awscdk.Duration_Seconds(jsii.Number(0)), // while developing
+		},
+	)
+
+	return authorizer
 }

--- a/internal/stack/network.go
+++ b/internal/stack/network.go
@@ -28,7 +28,7 @@ func NewNetworkStack(scope constructs.Construct, id string, props *NetworkStackP
 
 	vpc := awsec2.NewVpc(stack, jsii.String("vpc"), &awsec2.VpcProps{
 		IpAddresses:                  awsec2.IpAddresses_Cidr(jsii.String(CIDR)),
-		MaxAzs:                       jsii.Number(2),
+		MaxAzs:                       jsii.Number(1),
 		NatGateways:                  jsii.Number(0),
 		RestrictDefaultSecurityGroup: jsii.Bool(true),
 		SubnetConfiguration: &[]*awsec2.SubnetConfiguration{

--- a/internal/stack/network.go
+++ b/internal/stack/network.go
@@ -28,7 +28,7 @@ func NewNetworkStack(scope constructs.Construct, id string, props *NetworkStackP
 
 	vpc := awsec2.NewVpc(stack, jsii.String("vpc"), &awsec2.VpcProps{
 		IpAddresses:                  awsec2.IpAddresses_Cidr(jsii.String(CIDR)),
-		MaxAzs:                       jsii.Number(1),
+		MaxAzs:                       jsii.Number(2),
 		NatGateways:                  jsii.Number(0),
 		RestrictDefaultSecurityGroup: jsii.Bool(true),
 		SubnetConfiguration: &[]*awsec2.SubnetConfiguration{
@@ -65,11 +65,22 @@ func NewNetworkStack(scope constructs.Construct, id string, props *NetworkStackP
 		jsii.String("Allow connections to SecretsManager VPC endpoint."),
 		jsii.Bool(false))
 
+	// Select one of the VPC subnets in one of the availability zones to host the endpoint network interface
+	isoSel := vpc.SelectSubnets(&awsec2.SubnetSelection{
+		SubnetGroupName: jsii.String("private-subnet-isolated"),
+	})
+	oneAzSubnet := (*isoSel.Subnets)[0]
+
 	vpc.AddInterfaceEndpoint(jsii.String("secrets-manager-endpoint"), &awsec2.InterfaceVpcEndpointOptions{
 		Service:           awsec2.InterfaceVpcEndpointAwsService_SECRETS_MANAGER(),
 		PrivateDnsEnabled: jsii.Bool(true),
 		Open:              jsii.Bool(false),
 		SecurityGroups:    &[]awsec2.ISecurityGroup{secretsManagerVpcEndpointSecurityGroup},
+		Subnets: &awsec2.SubnetSelection{
+			Subnets: &[]awsec2.ISubnet{
+				oneAzSubnet,
+			},
+		},
 	})
 
 	return &NetworkStack{

--- a/internal/stack/productionApi.go
+++ b/internal/stack/productionApi.go
@@ -3,8 +3,6 @@ package stack
 import (
 	gateway_parameters "cdk-infrastructure/gateway/parameters"
 	gateway_routes "cdk-infrastructure/gateway/routes"
-	"os"
-	"strings"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2" // core
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsec2"
@@ -17,7 +15,7 @@ import (
 	"github.com/aws/jsii-runtime-go"
 )
 
-type ApiStackProps struct {
+type ProdApiStackProps struct {
 	Props awscdk.StackProps
 
 	Vpc                               awsec2.Vpc
@@ -31,7 +29,7 @@ type ApiStackProps struct {
 	Authorizer awsapigatewayv2.IHttpRouteAuthorizer
 }
 
-func NewApiStack(scope constructs.Construct, id string, props *ApiStackProps) awscdk.Stack {
+func NewProdApiStack(scope constructs.Construct, id string, props *ProdApiStackProps) awscdk.Stack {
 	var sprops awscdk.StackProps
 	if props != nil {
 		sprops = props.Props
@@ -56,19 +54,7 @@ func NewApiStack(scope constructs.Construct, id string, props *ApiStackProps) aw
 		},
 	})
 
-	var databaseName string
-	productionStatus := strings.ToLower(os.Getenv("PRODUCTION_STATUS"))
-
-	if productionStatus == "true" {
-		databaseName = "PRODUCTION"
-	} else {
-		databaseName = "STAGING"
-	}
-
-	awscdk.NewCfnOutput(stack, jsii.String("DeploymentStatus"), &awscdk.CfnOutputProps{
-		Value:       jsii.String(databaseName),
-		Description: jsii.String("The deployment status, either 'PROD' or 'STAGING'"),
-	})
+	const databaseName string = "PRODUCTION"
 
 	vpc := props.Vpc
 
@@ -98,13 +84,6 @@ func NewApiStack(scope constructs.Construct, id string, props *ApiStackProps) aw
 	gateway_routes.PublicEventRoutes(httpApi, stack, vpc, dbParams)
 
 	gateway_routes.StudentMeRoutes(httpApi, stack, vpc, dbParams, authorizer)
-	// gateway_routes.DatabaseRoutes(httpApi, stack, gateway_routes.DatabaseRouteProps{
-	// 	Vpc:                               props.Vpc,
-	// 	LambdaSecretsManagerSecurityGroup: props.LambdaSecretsManagerSecurityGroup,
-	// 	DbInstance:                        props.DbInstance,
-	// 	ProxyEndpoint:                     props.ProxyEndpoint,
-	// 	LambdaSecurityGroup:               props.LambdaSecurityGroup,
-	// })
 
 	// log HTTP API endpoint
 	awscdk.NewCfnOutput(stack, jsii.String("myHttpApiEndpoint"), &awscdk.CfnOutputProps{

--- a/utils/query_client/queries/clubs/SELECT_club.sql
+++ b/utils/query_client/queries/clubs/SELECT_club.sql
@@ -6,7 +6,6 @@ SELECT
   ci.description AS description,
   ci.website_url AS website_url
 FROM clubs c
-INNER JOIN verified_clubs vc ON vc.fk_club_id = c.id
 LEFT JOIN images     i  ON i.id = c.fk_logo_id
 LEFT JOIN club_info  ci ON ci.fk_club_id = c.id
 WHERE c.id = ?


### PR DESCRIPTION
This PR separates our one API Gateway stack into two separate ones in order to keep a production environment stable while we add new endpoints.

It also specifies the subnet and thus availability zone that our secrets manager interface endpoint handles, thus removing the double endpoint hour usage per month and slashing our VPC costs in half.

**Edit:** As of 12/7/25, after talks with Kyle on the details of the GET /clubs/{clubId} endpoint, this PR now reverts that endpoint back to its intended functionality of showing all verified and unverified clubs.