### PR TITLE
Add join/leave club membership endpoints for /clubs/{clubId}

### DIFF
--- a/gateway/integrations/clubs.go
+++ b/gateway/integrations/clubs.go
@@ -209,3 +209,85 @@ func PostNewClub(
 
 	return integration
 }
+
+func PostJoinClubMemberMe(
+	stack awscdk.Stack,
+	vpc awsec2.IVpc,
+	dbParams gateway_parameters.DatabaseConnectionParameters,
+) awsapigatewayv2integrations.HttpLambdaIntegration {
+	host := dbParams.DbHost
+	dbName := dbParams.DbName
+	arn := dbParams.Secret.SecretArn()
+	lambdaSG := dbParams.LambdaSG
+	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
+
+	function := awscdklambdagoalpha.NewGoFunction(
+		stack,
+		jsii.String("PostJoinClubMemberMeFunction"),
+		&awscdklambdagoalpha.GoFunctionProps{
+			FunctionName: jsii.String("PostJoinClubMemberMe"),
+			Description:  jsii.String("Join a club as the current student"),
+			Entry:        jsii.String("lambda/api/clubs/clubId/members/me/post/post.go"),
+			Environment: &map[string]*string{
+				"DB_SECRET_ARN": arn,
+				"DB_HOST":       jsii.String(host),
+				"DB_NAME":       jsii.String(dbName),
+			},
+			Vpc:     vpc,
+			Timeout: awscdk.Duration_Minutes(jsii.Number(1)),
+			SecurityGroups: &[]awsec2.ISecurityGroup{
+				lambdaSG,
+				lambdaToSecretsManagerSG,
+			},
+		},
+	)
+
+	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
+
+	return awsapigatewayv2integrations.NewHttpLambdaIntegration(
+		jsii.String("PostJoinClubMemberMeIntegration"),
+		function,
+		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
+	)
+}
+
+func DeleteClubMemberMe(
+	stack awscdk.Stack,
+	vpc awsec2.IVpc,
+	dbParams gateway_parameters.DatabaseConnectionParameters,
+) awsapigatewayv2integrations.HttpLambdaIntegration {
+	host := dbParams.DbHost
+	dbName := dbParams.DbName
+	arn := dbParams.Secret.SecretArn()
+	lambdaSG := dbParams.LambdaSG
+	lambdaToSecretsManagerSG := dbParams.LambdaToSecretsManagerSG
+
+	function := awscdklambdagoalpha.NewGoFunction(
+		stack,
+		jsii.String("DeleteClubMemberMeFunction"),
+		&awscdklambdagoalpha.GoFunctionProps{
+			FunctionName: jsii.String("DeleteClubMemberMe"),
+			Description:  jsii.String("Leave a club as the current student"),
+			Entry:        jsii.String("lambda/api/clubs/clubId/members/me/delete/delete.go"),
+			Environment: &map[string]*string{
+				"DB_SECRET_ARN": arn,
+				"DB_HOST":       jsii.String(host),
+				"DB_NAME":       jsii.String(dbName),
+			},
+			Vpc:     vpc,
+			Timeout: awscdk.Duration_Minutes(jsii.Number(1)),
+			SecurityGroups: &[]awsec2.ISecurityGroup{
+				lambdaSG,
+				lambdaToSecretsManagerSG,
+			},
+		},
+	)
+
+	gateway_helpers.GrantRdsAccessToLambda(function, dbParams.DbInstance, dbParams.Secret)
+
+	return awsapigatewayv2integrations.NewHttpLambdaIntegration(
+		jsii.String("DeleteClubMemberMeIntegration"),
+		function,
+		&awsapigatewayv2integrations.HttpLambdaIntegrationProps{},
+	)
+}

--- a/gateway/routes/club_routes.go
+++ b/gateway/routes/club_routes.go
@@ -13,7 +13,12 @@ import (
 // Helper function to add club routes to the API.
 // Routes:
 //
-// POST /clubs/{clubId}/events
+//	GET    /clubs
+//	GET    /clubs/{clubId}
+//	GET    /clubs/{clubId}/events
+//	POST   /clubs/{clubId}/events
+//	POST   /clubs/{clubId}/members/me
+//	DELETE /clubs/{clubId}/members/me
 func ClubRoutes(
 	httpApi awsapigatewayv2.HttpApi,
 	stack awscdk.Stack,
@@ -30,7 +35,7 @@ func ClubRoutes(
 		Integration: integrations.GetClubsByVerification(stack, vpc, dbParams),
 	})
 
-	// Get /clubs/{clubId}
+	// GET /clubs/{clubId}
 	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
 		Path: jsii.String("/clubs/{clubId}"),
 		Methods: &[]awsapigatewayv2.HttpMethod{
@@ -58,4 +63,23 @@ func ClubRoutes(
 		Authorizer:  authorizer,
 	})
 
+	// POST /clubs/{clubId}/members/me  (join club as current student)
+	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
+		Path: jsii.String("/clubs/{clubId}/members/me"),
+		Methods: &[]awsapigatewayv2.HttpMethod{
+			awsapigatewayv2.HttpMethod_POST,
+		},
+		Integration: integrations.PostJoinClubMemberMe(stack, vpc, dbParams),
+		Authorizer:  authorizer,
+	})
+
+	// DELETE /clubs/{clubId}/members/me  (leave club as current student)
+	httpApi.AddRoutes(&awsapigatewayv2.AddRoutesOptions{
+		Path: jsii.String("/clubs/{clubId}/members/me"),
+		Methods: &[]awsapigatewayv2.HttpMethod{
+			awsapigatewayv2.HttpMethod_DELETE,
+		},
+		Integration: integrations.DeleteClubMemberMe(stack, vpc, dbParams),
+		Authorizer:  authorizer,
+	})
 }

--- a/internal/stack/api.go
+++ b/internal/stack/api.go
@@ -49,6 +49,7 @@ func NewApiStack(scope constructs.Construct, id string, props *ApiStackProps) aw
 				awsapigatewayv2.CorsHttpMethod_POST,
 				awsapigatewayv2.CorsHttpMethod_OPTIONS,
 				awsapigatewayv2.CorsHttpMethod_PATCH,
+				awsapigatewayv2.CorsHttpMethod_DELETE,
 			},
 			AllowOrigins: &[]*string{
 				jsii.String("*"), // allowing from all origins atm, should be locked down later

--- a/lambda/api/clubs/clubId/members/me/delete/delete.go
+++ b/lambda/api/clubs/clubId/members/me/delete/delete.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	gateway_helpers "cdk-infrastructure/gateway/helpers"
+	authentication_utils "cdk-infrastructure/utils/auth"
+	"cdk-infrastructure/utils/query_client"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+var (
+	qc *query_client.QueryClient
+)
+
+func init() {
+	dbName := os.Getenv("DB_NAME")
+	arn := os.Getenv("DB_SECRET_ARN")
+	host := os.Getenv("DB_HOST")
+
+	client, err := query_client.NewClientFromHost(context.Background(), arn, dbName, host)
+	if err != nil {
+		log.Printf("Error creating query client: %v", err)
+		panic(err)
+	}
+
+	qc = client
+}
+
+func handler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	// Extract sub and email from JWT
+	sub, email, err := authentication_utils.ExtractSubFromRequest(request.RequestContext)
+	if err != nil {
+		log.Printf("Error extracting sub from request: %v", err)
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			fmt.Sprintf("Error extracting sub from request: %v", err),
+			nil,
+		)
+	}
+
+	// Ensure student exists
+	if err := authentication_utils.RequireStudent(ctx, qc, sub, email); err != nil {
+		log.Printf("Error ensuring student exists: %v", err)
+		return gateway_helpers.NewServerErrorGatewayResponse(
+			fmt.Sprintf("Error ensuring student exists: %v", err),
+			nil,
+		)
+	}
+
+	// Validate clubId path parameter
+	clubIdStr := request.PathParameters["clubId"]
+	if clubIdStr == "" {
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			"clubId is required in path parameters",
+			nil,
+		)
+	}
+
+	clubId, err := strconv.Atoi(clubIdStr)
+	if err != nil {
+		log.Printf("Error converting clubId to integer: %v", err)
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			"clubId must be a valid integer",
+			nil,
+		)
+	}
+
+	// Leave club. SQL should:
+	//   - delete membership only if not owner
+	//   - return 0 rows affected if user is not a member or is owner
+	leaveQuery := query_client.NewQuery(
+		"clubs/DELETE_club_member.sql",
+		sub,    // fk_student_id = ?
+		clubId, // fk_club_id = ?
+	)
+
+	result, err := qc.Exec(leaveQuery)
+	if err != nil {
+		log.Printf("Error executing club member delete query: %v", err)
+		return gateway_helpers.NewServerErrorGatewayResponse(
+			"Error leaving club",
+			nil,
+		)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		log.Printf("Error getting rows affected for leave club: %v", err)
+		return gateway_helpers.NewServerErrorGatewayResponse(
+			"Error leaving club",
+			nil,
+		)
+	}
+
+	if rows == 0 {
+		// Either not a member, or they are the owner and the SQL protected the row.
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			"Unable to leave club. You may not be a member or you are the club owner.",
+			nil,
+		)
+	}
+
+	log.Printf("Student %s left club %d", sub, clubId)
+
+	response := map[string]any{
+		"clubId": clubId,
+		"left":   true,
+	}
+
+	return gateway_helpers.NewSuccessGatewayResponse(
+		"Successfully left club",
+		response,
+	)
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/lambda/api/clubs/clubId/members/me/post/post.go
+++ b/lambda/api/clubs/clubId/members/me/post/post.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	gateway_helpers "cdk-infrastructure/gateway/helpers"
+	authentication_utils "cdk-infrastructure/utils/auth"
+	"cdk-infrastructure/utils/query_client"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+var (
+	qc *query_client.QueryClient
+)
+
+func init() {
+	dbName := os.Getenv("DB_NAME")
+	arn := os.Getenv("DB_SECRET_ARN")
+	host := os.Getenv("DB_HOST")
+
+	client, err := query_client.NewClientFromHost(context.Background(), arn, dbName, host)
+	if err != nil {
+		log.Printf("Error creating query client: %v", err)
+		panic(err)
+	}
+
+	qc = client
+}
+
+func handler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	// Extract sub and email from JWT
+	sub, email, err := authentication_utils.ExtractSubFromRequest(request.RequestContext)
+	if err != nil {
+		log.Printf("Error extracting sub from request: %v", err)
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			fmt.Sprintf("Error extracting sub from request: %v", err),
+			nil,
+		)
+	}
+
+	// Ensure student exists (or upsert if needed)
+	if err := authentication_utils.RequireStudent(ctx, qc, sub, email); err != nil {
+		log.Printf("Error ensuring student exists: %v", err)
+		return gateway_helpers.NewServerErrorGatewayResponse(
+			fmt.Sprintf("Error ensuring student exists: %v", err),
+			nil,
+		)
+	}
+
+	// Validate clubId path parameter
+	clubIdStr := request.PathParameters["clubId"]
+	if clubIdStr == "" {
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			"clubId is required in path parameters",
+			nil,
+		)
+	}
+
+	clubId, err := strconv.Atoi(clubIdStr)
+	if err != nil {
+		log.Printf("Error converting clubId to integer: %v", err)
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			"clubId must be a valid integer",
+			nil,
+		)
+	}
+
+	// Join club. SQL should:
+	//   - ensure student and club exist
+	//   - avoid duplicate membership
+	//   - return 0 rows affected if join is not possible
+	joinQuery := query_client.NewQuery(
+		"clubs/INSERT_club_member.sql",
+		clubId, // matches `JOIN clubs c ON c.id = ?`
+		sub,    // matches `WHERE s.id = ?`
+	)
+
+	result, err := qc.Exec(joinQuery)
+	if err != nil {
+		log.Printf("Error executing club member insert query: %v", err)
+		return gateway_helpers.NewServerErrorGatewayResponse(
+			"Error joining club",
+			nil,
+		)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		log.Printf("Error getting rows affected for join club: %v", err)
+		return gateway_helpers.NewServerErrorGatewayResponse(
+			"Error joining club",
+			nil,
+		)
+	}
+
+	if rows == 0 {
+		// No insert: either club does not exist, student does not exist,
+		// or user is already a member.
+		return gateway_helpers.NewClientErrorGatewayResponse(
+			"Unable to join club. You may already be a member or the club does not exist.",
+			nil,
+		)
+	}
+
+	log.Printf("Student %s joined club %d", sub, clubId)
+
+	response := map[string]any{
+		"clubId": clubId,
+		"joined": true,
+	}
+
+	return gateway_helpers.NewSuccessGatewayResponse(
+		"Successfully joined club",
+		response,
+	)
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/utils/query_client/queries/clubs/DELETE_club_member.sql
+++ b/utils/query_client/queries/clubs/DELETE_club_member.sql
@@ -1,0 +1,7 @@
+-- DELETE_club_member.sql
+-- Leave a club if the student is a member and not the owner.
+
+DELETE FROM club_members
+WHERE fk_student_id   = ?
+  AND fk_club_id      = ?
+  AND member_is_owner = FALSE;

--- a/utils/query_client/queries/clubs/INSERT_club_member.sql
+++ b/utils/query_client/queries/clubs/INSERT_club_member.sql
@@ -1,0 +1,26 @@
+-- INSERT_club_member.sql
+-- Join a club as a regular member if:
+--   1) the club exists
+--   2) the student exists (optional, see note)
+--   3) the student is not already a member
+
+INSERT INTO club_members (
+    fk_student_id,
+    fk_club_id,
+    member_is_eboard,
+    member_is_owner
+)
+SELECT
+    s.id        AS fk_student_id,
+    c.id        AS fk_club_id,
+    FALSE       AS member_is_eboard,
+    FALSE       AS member_is_owner
+FROM students s
+JOIN clubs c ON c.id = ?
+WHERE s.id = ?
+  AND NOT EXISTS (
+      SELECT 1
+      FROM club_members cm
+      WHERE cm.fk_student_id = s.id
+        AND cm.fk_club_id    = c.id
+  );


### PR DESCRIPTION
## Summary

Note: i used gpt to generate this pr message im too lazy to write this all out

Expose authenticated join/leave actions for clubs via new `/clubs/{clubId}/members/me` endpoints, backed by safe one-statement SQL that enforces membership rules and avoids foreign key errors.

## Changes

### API routes / CDK

- Updated `ClubRoutes` to add:
  - `POST /clubs/{clubId}/members/me` (join current club)
  - `DELETE /clubs/{clubId}/members/me` (leave current club)
- Wired new integrations in `gateway/integrations/clubs.go`:
  - `PostJoinClubMemberMe`
  - `DeleteClubMemberMe`
- Ensured new Lambdas reuse the existing VPC and security group wiring (same pattern as other club/event Lambdas).

### Lambda handlers

kyle note: didnt realize we can have only one handler per folder
mistake on my end, but we can deal with refactor as we go if that's not too much trouble

- Added `lambda/api/clubs/clubId/members/me/post/main.go`:
  - Extracts `sub` and `email` from JWT.
  - Calls `RequireStudent` to ensure the student exists.
  - Validates `clubId` path parameter as an integer.
  - Executes `clubs/INSERT_club_member.sql`.
  - Uses `RowsAffected` to distinguish success vs no-op (already member, missing club/student, etc.).

- Added `lambda/api/clubs/clubId/members/me/delete/main.go`:
  - Same auth flow as join (JWT + `RequireStudent`).
  - Validates `clubId`.
  - Executes `clubs/DELETE_club_member.sql`.
  - Uses `RowsAffected` to handle cases where the user is not a member or is the owner and cannot leave.

### SQL

Kyle note: we never check that clubid corresponds to an actual club with a helper
so i just put it in the mysql query

- Added `clubs/INSERT_club_member.sql`:
  - Single-statement insert that:
    - Requires existing `students` and `clubs` rows.
    - Avoids duplicate membership via `NOT EXISTS`.
    - Fails safely with `RowsAffected = 0` instead of throwing foreign key errors.
- Added `clubs/DELETE_club_member.sql`:
  - Deletes from `club_members` only when:
    - `fk_student_id` matches the current user.
    - `fk_club_id` matches.
    - `member_is_owner = FALSE` (owner cannot leave via this endpoint).

## Design notes

- No new Go models added; membership operations are write-only and rely on `RowsAffected` for control flow.
- Error responses for join/leave are intentionally generic. To keep the SQL as a single statement, the Lambda does not distinguish between “club missing,” “student missing,” or “already a member” beyond checking whether any rows were affected.

## Testing

- `cdk synth ApiStack` to verify CDK wiring.
- `cdk deploy ApiStack` after adding the new integrations.
- Manual smoke testing:
  - `POST /clubs/{clubId}/members/me` with a valid JWT and existing `clubId`.
  - `DELETE /clubs/{clubId}/members/me` with:
    - an existing membership.
    - no membership.
    - a user who is the club owner (should not be able to leave).